### PR TITLE
Migrate to Bootstrap 5.0.0.alpha3

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -5,8 +5,8 @@
     <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
       <%= render partial: 'devise/shared/error_messages', resource: resource %>
 
-      <div class="form-group">
-        <%= f.label :email %><br />
+      <div class="mb-3">
+        <%= f.label :email, class: 'form-label' %><br />
         <%= f.email_field :email, autofocus: true, class: 'form-control', value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
       </div>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -6,18 +6,18 @@
 	 <%= render partial: 'devise/shared/error_messages', resource: resource %>
       <%= f.hidden_field :reset_password_token %>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.password_field :password, autofocus: true, autocomplete: "off", class: 'form-control', placeholder: "Password" %>
         <% if @minimum_password_length %>
           <p class="text-muted"><small><%= @minimum_password_length %> characters minimum</small></p>
         <% end %>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: "Confirm Password" %>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.submit "Change my password", class: 'btn btn-primary btn-block btn-lg' %>
       </div>
     <% end %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -5,11 +5,11 @@
       <%= render partial: 'devise/shared/error_messages', resource: resource %>
       <br>
       <p class="text-center">Enter your email address below and we will send you a link to reset your password.</p>
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.email_field :email, autofocus: true, placeholder: 'Email Address', class: 'form-control' %>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.submit "Send password reset email", class: 'btn btn-primary btn-block btn-lg' %>
       </div>
     <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -5,7 +5,7 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
       <%= render partial: 'devise/shared/error_messages', resource: resource %>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.email_field :email, class: 'form-control', placeholder: 'Email Address' %>
       </div>
 
@@ -13,21 +13,21 @@
         <div class="alert alert-warning">Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
       <% end %>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.password_field :password, autocomplete: "off", class: 'form-control', placeholder: 'Password'  %>
         <p class="form-text text-muted"><small>Leave password blank if you don't want to change it</small></p>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: 'Confirm Password'  %>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.password_field :current_password, autocomplete: "off", class: 'form-control', placeholder: 'Current Password'  %>
         <p class="form-text text-muted"><small>We need your current password to confirm your changes</small></p>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.submit "Save Changes", class: 'btn btn-lg btn-block btn-primary' %>
       </div>
     <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -5,19 +5,19 @@
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
       <%= render partial: 'devise/shared/error_messages', resource: resource %>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.email_field :email, autofocus: false, class: 'form-control', placeholder: "Email Address" %>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.password_field :password, autocomplete: "off", class: 'form-control', placeholder: 'Password' %>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: 'Confirm Password' %>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.submit "Sign up", class: "btn btn-primary btn-block btn-lg" %>
       </div>
     <% end %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -3,11 +3,11 @@
     <h1 class="text-center">Log in</h1>
 
     <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.email_field :email, autofocus: true, placeholder: 'Email Address', class: 'form-control' %>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.password_field :password, autocomplete: "off", placeholder: 'Password', class: 'form-control' %>
       </div>
 
@@ -20,7 +20,7 @@
         </div>
       <% end -%>
 
-      <div class="form-group">
+      <div class="mb-3">
         <%= f.submit "Log in", class: "btn btn-primary btn-block btn-lg" %>
       </div>
     <% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -4,7 +4,7 @@
   <%= render partial: 'devise/shared/error_messages', resource: resource %>
 
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :email, class: 'form-label' %><br />
     <%= f.email_field :email, autofocus: true %>
   </div>
 

--- a/lib/devise/generators/bootstrapped_generator.rb
+++ b/lib/devise/generators/bootstrapped_generator.rb
@@ -4,7 +4,7 @@ require 'rails/generators'
 module Devise
   module Views
     class BootstrappedGenerator < Rails::Generators::Base
-      desc "Copies views styled for Bootstrap 3"
+      desc "Copies views styled for Bootstrap 5"
 
       source_root File.expand_path("../../../..", __FILE__)
 


### PR DESCRIPTION
* Implement new `.form-label` class. Docs say:
> Form labels now require the .form-label class. Sass variables are now available to style form labels to your needs. [See #30476](https://github.com/twbs/bootstrap/pull/30476)

* Drop `.form-group`. This method has been removed in Bootstrap 5. The maintainers replaced it in their docs with `.mb-3` and I have done the same.