### PR TITLE
Deprecate .btn-block class

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -10,8 +10,8 @@
         <%= f.email_field :email, autofocus: true, class: 'form-control', value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email) %>
       </div>
 
-      <div class="actions">
-        <%= f.submit "Resend confirmation instructions", class: 'btn btn-primary btn-lg btn-block' %>
+      <div class="actions d-grid">
+        <%= f.submit "Resend confirmation instructions", class: 'btn btn-primary btn-lg' %>
       </div>
     <% end %>
 

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -17,8 +17,8 @@
         <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: "Confirm Password" %>
       </div>
 
-      <div class="mb-3">
-        <%= f.submit "Change my password", class: 'btn btn-primary btn-block btn-lg' %>
+      <div class="mb-3 d-grid">
+        <%= f.submit "Change my password", class: 'btn btn-primary btn-lg' %>
       </div>
     <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -9,8 +9,8 @@
         <%= f.email_field :email, autofocus: true, placeholder: 'Email Address', class: 'form-control' %>
       </div>
 
-      <div class="mb-3">
-        <%= f.submit "Send password reset email", class: 'btn btn-primary btn-block btn-lg' %>
+      <div class="mb-3 d-grid">
+        <%= f.submit "Send password reset email", class: 'btn btn-primary btn-lg' %>
       </div>
     <% end %>
     <div class="text-center">

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -27,8 +27,8 @@
         <p class="form-text text-muted"><small>We need your current password to confirm your changes</small></p>
       </div>
 
-      <div class="mb-3">
-        <%= f.submit "Save Changes", class: 'btn btn-lg btn-block btn-primary' %>
+      <div class="mb-3 d-grid">
+        <%= f.submit "Save Changes", class: 'btn btn-lg btn-primary' %>
       </div>
     <% end %>
     <hr>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,8 +17,8 @@
         <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: 'Confirm Password' %>
       </div>
 
-      <div class="mb-3">
-        <%= f.submit "Sign up", class: "btn btn-primary btn-block btn-lg" %>
+      <div class="mb-3 d-grid">
+        <%= f.submit "Sign up", class: "btn btn-primary btn-lg" %>
       </div>
     <% end %>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -20,8 +20,8 @@
         </div>
       <% end -%>
 
-      <div class="mb-3">
-        <%= f.submit "Log in", class: "btn btn-primary btn-block btn-lg" %>
+      <div class="mb-3 d-grid">
+        <%= f.submit "Log in", class: "btn btn-primary btn-lg" %>
       </div>
     <% end %>
 


### PR DESCRIPTION
I neglected to deprecate the `.btn-block` class, which has been deprecated in Bootstrap 5 in favor of display and gap classes applied to the parent container. Attached is the view with these changes applied.

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/2475615/99324823-0c58d400-2843-11eb-9188-aab6cb689394.png">
